### PR TITLE
Adjusting crontab so it runs once every two months

### DIFF
--- a/rootco/web/init.sls
+++ b/rootco/web/init.sls
@@ -35,7 +35,10 @@ certbot:
 /opt/certbot/certbot-auto renew >/dev/null 2>&1:
   cron.present:
     - user: root
-    - daymonth: '*/60'
+    - minute: 0
+    - hour: 0
+    - daymonth: 1
+    - month: */2
     - require:
       - git: certbot
 


### PR DESCRIPTION
Hi, I just happened across your crontab since I'm looking to add certbot to my machine via salt.

I think your syntax doesn't do what you want it to do... and if I'm incorrect, forgive me for butting in.

Salt's cron state defaults to `*` for unspecified values.  Which means if you had a `daymonth` that worked... that day would be very busy for your servers.

daymonth of `*/60` didn't seem to make sense, since it would only evaluate if daymonth: 0, 60, 120... etc.  Which never happens.

Again, if you think I misinterpreted just let me know.  This is kind of a drive-by Pull Request.
